### PR TITLE
ci(ci.yml): add commitlint and autosquash checks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
     - uses: ./.github/actions/set-up-node
     - name: npm install and build
       run: |
@@ -23,3 +23,27 @@ jobs:
       run: npx playwright install --with-deps
     - name: E2E tests
       run: npm run test:e2e
+
+  commitlint:
+    name: Commitlint
+    permissions:
+      contents: read
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        if: github.actor != 'dependabot[bot]' && github.event_name != 'merge_group'
+      - uses: wagoid/commitlint-github-action@b948419dd99f3fd78a6548d48f94e3df7f6bf3ed # v6.2.1
+        if: github.actor != 'dependabot[bot]' && github.event_name != 'merge_group'
+
+  autosquash:
+    name: Block Autosquash Commits
+    permissions:
+      pull-requests: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Block Autosquash Commits
+        if: github.event_name != 'merge_group'
+        uses: xt0rted/block-autosquash-commits-action@79880c36b4811fe549cfffe20233df88876024e7 # v2.2.0
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add commitlint and autosquash jobs to CI workflow.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * CI updated to use pinned action versions for more reproducible runs.
  * Added a commit message validation job to enforce commit standards, with guards to skip automated dependency/merge workflows.
  * Added a job to block autosquash commits to prevent unwanted automated amend/rebase workflows; this job also skips specific automated merge events.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->